### PR TITLE
fix: update Node.js to 26.4.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-bookworm AS base
+FROM node:26.4.0-bookworm AS base
 RUN apt-get update && apt-get install -y git curl zsh tree bash-completion vim \
     && npm install -g pnpm@10 \
     && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \


### PR DESCRIPTION
## Summary

- Dockerfile の Node.js ベースイメージを `24.15.0-bookworm` → `26.4.0-bookworm` に更新

## Test plan

- [x] ローカルで `docker build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)