### PR TITLE
fix: update pnpm to 11.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:26.4.0-bookworm AS base
 RUN apt-get update && apt-get install -y git curl zsh tree bash-completion vim \
-    && npm install -g pnpm@10 \
+    && npm install -g pnpm@11 \
     && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \
     && echo 'export SHELL=/usr/bin/zsh' >> /etc/profile \
     && echo 'export DEFAULT_USER=root' >> /etc/zsh/zshrc \

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
   "dependencies": {
     "gray-matter": "4.0.3"
   },
-  "packageManager": "pnpm@11.9.0+sha512.vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw=="
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/package.json
+++ b/package.json
@@ -17,19 +17,8 @@
     "vitepress": "1.6.4",
     "vue": "3.5.33"
   },
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
-    },
-    "ignoredBuiltDependencies": [
-      "esbuild",
-      "vue-demi"
-    ]
-  },
   "dependencies": {
     "gray-matter": "4.0.3"
   },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  "packageManager": "pnpm@11.9.0+sha512.vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw=="
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm.json
+++ b/pnpm.json
@@ -1,0 +1,7 @@
+{
+  "peerDependencyRules": {
+    "ignoreMissing": [
+      "@algolia/client-search"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- `packageManager` を `pnpm@10.33.2` → `pnpm@11.9.0` に更新
- `package.json` の非推奨 `pnpm` フィールドを `pnpm.json` に移行
- pnpm 11 の build approval 機能に対応 (`pnpm-workspace.yaml` で esbuild を許可)
- Dockerfile の `pnpm@10` → `pnpm@11` に更新

## Test plan

- [x] CI ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)